### PR TITLE
修复issue#7 & 修复自定义storeDir后生成的@/helper/pinia-auto-refs.ts的引入引入路径错误

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,8 @@ export default function (options: Options = {}) {
 
   const { storeDir, excludes, outputFile,isDev } = options as Required<Options>
   const storePath = resolve(process.cwd(), storeDir)
-  const outputDir = outputFile.replace(/(\/[^/]*).ts/, '')
+  const outputFileInfo = parse(outputFile)
+  const outputDir = outputFileInfo.dir || './' // outputFile.replace(/(\/[^/]*).ts/, '')
   fs.readdir(outputDir).catch(() => fs.mkdir(outputDir))
 
   async function generateConfigFiles() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs'
-import { resolve } from 'path'
+import { resolve, parse, relative } from 'path'
 import chokidar from 'chokidar'
 
 type Options = Partial<{
@@ -23,6 +23,7 @@ export default function (options: Options = {}) {
   const storePath = resolve(process.cwd(), storeDir)
   const outputFileInfo = parse(outputFile)
   const outputDir = outputFileInfo.dir || './' // outputFile.replace(/(\/[^/]*).ts/, '')
+  const relativePath = relative(outputDir, storePath).replaceAll('\\', '/')
   fs.readdir(outputDir).catch(() => fs.mkdir(outputDir))
 
   async function generateConfigFiles() {
@@ -39,17 +40,11 @@ export default function (options: Options = {}) {
 import type { AutoToRefs, ToRef } from 'vue'
 
 ${storeNames.reduce(
-  (str, storeName) => `${str}import ${storeName}Store from '${storeDir.replace(
-    'src',
-    '@'
-  )}/${storeName}'
+  (str, storeName) => `${str}import ${storeName}Store from '${relativePath}/${storeName}'
 `,
   ''
 )}
-import store from '${storeDir.replace(
-  'src',
-  '@'
-)}'
+import store from '${relativePath}'
 
 declare module 'vue' {
   export type AutoToRefs<T> = {


### PR DESCRIPTION
1. 将正则表达式改为path.parse解析路径
2. 修复自定义storeDir后生成的@/helper/pinia-auto-refs.ts的引入引入路径错误